### PR TITLE
add build-fail test for simd type with an element type that's a wide pointer

### DIFF
--- a/src/test/ui/simd/simd-type-generic-monomorphisation-extern-nonnull-ptr.rs
+++ b/src/test/ui/simd/simd-type-generic-monomorphisation-extern-nonnull-ptr.rs
@@ -1,0 +1,23 @@
+// run-pass
+// ignore-emscripten
+
+#![feature(extern_types)]
+#![feature(repr_simd)]
+
+use std::ptr::NonNull;
+
+extern {
+    type Extern;
+}
+
+#[repr(simd)]
+struct S<T>(T);
+
+#[inline(never)]
+fn identity<T>(v: T) -> T {
+    v
+}
+
+fn main() {
+    let _v: S<[Option<NonNull<Extern>>; 4]> = identity(S([None; 4]));
+}

--- a/src/test/ui/simd/simd-type-generic-monomorphisation-wide-ptr.rs
+++ b/src/test/ui/simd/simd-type-generic-monomorphisation-wide-ptr.rs
@@ -1,0 +1,12 @@
+// build-fail
+
+#![feature(repr_simd)]
+
+// error-pattern:monomorphising SIMD type `S<[*mut [u8]; 4]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+
+#[repr(simd)]
+struct S<T>(T);
+
+fn main() {
+    let _v: Option<S<[*mut [u8]; 4]>> = None;
+}

--- a/src/test/ui/simd/simd-type-generic-monomorphisation-wide-ptr.stderr
+++ b/src/test/ui/simd/simd-type-generic-monomorphisation-wide-ptr.stderr
@@ -1,0 +1,4 @@
+error: monomorphising SIMD type `S<[*mut [u8]; 4]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/simd/simd-type-wide-ptr.rs
+++ b/src/test/ui/simd/simd-type-wide-ptr.rs
@@ -1,0 +1,12 @@
+// build-fail
+
+#![feature(repr_simd)]
+
+// error-pattern:monomorphising SIMD type `S` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+
+#[repr(simd)]
+struct S([*mut [u8]; 4]);
+
+fn main() {
+    let _v: Option<S> = None;
+}

--- a/src/test/ui/simd/simd-type-wide-ptr.stderr
+++ b/src/test/ui/simd/simd-type-wide-ptr.stderr
@@ -1,0 +1,4 @@
+error: monomorphising SIMD type `S` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
added test case as requested https://github.com/rust-lang/rust/pull/85919#issuecomment-852587027